### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#MvcRazorToPdf
+# MvcRazorToPdf
 Create pdf documents within an asp .net mvc project by generating your views as normal but returning a PdfActionResult.
 
 *Demo link to follow
@@ -7,20 +7,20 @@ This converts regular produced razor/html to pdf documents in the browser using 
 
 This uses the newer version/licence of iText/iTextXmlWorker and can process the html that is produced from your views.
 
-##Installation instructions:
+## Installation instructions:
 
 Run the following nuget command from your mvc project to install the [package] (http://nuget.org/packages/MvcRazorToPdf/):
 
 `Install-Package MvcRazorToPdf`
 
-##How to use it
+## How to use it
 1. Create a shared layout that is compatible with an iTextXmlWorker document [Simple example layout] (https://github.com/andyhutch77/MvcRazorToPdf/blob/master/MvcRazorToPdfExample/Views/Shared/_PdfLayout.cshtml)
 2. Create a controller action that return a PdfActionResult (model optional) [Simple example contoller] (https://github.com/andyhutch77/MvcRazorToPdf/blob/master/MvcRazorToPdfExample/Controllers/PdfController.cs)
 3. Create the view page to render as normal [Simple example view] (https://github.com/andyhutch77/MvcRazorToPdf/blob/master/MvcRazorToPdfExample/Views/Pdf/Index.cshtml)
 
 [Complete example project] (https://github.com/andyhutch77/MvcRazorToPdf/tree/master/MvcRazorToPdfExample)
 
-##Useful info
+## Useful info
 
 [iTextXmlWorker docs] (http://demo.itextsupport.com/xmlworker/itextdoc/flatsite.html).
 [http://demo.itextsupport.com/xmlworker/] (http://demo.itextsupport.com/xmlworker/) if you have problems getting certain styles to render.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
